### PR TITLE
Generate ical description dynamically

### DIFF
--- a/symposion/schedule/views.py
+++ b/symposion/schedule/views.py
@@ -270,7 +270,8 @@ class EventFeed(ICalFeed):
     product_id = '-//linux.conf.au/schedule//EN'
     timezone = settings.TIME_ZONE
     filename = 'conference.ics'
-    description = Conference.objects.all().first().title
+    def description(self):
+        return Conference.objects.all().first().title
 
     def items(self):
         return Slot.objects.filter(


### PR DESCRIPTION
Use method instead of class attribute for ical feed description.
This allows the class to be instantiated without a database being available (eg. during migrate).